### PR TITLE
fix type error

### DIFF
--- a/src/service/user.service.ts
+++ b/src/service/user.service.ts
@@ -29,7 +29,7 @@ export async function validatePassword({
 
   if (!isValid) return false;
 
-  return omit(user.toJSON(), "password");
+  return omit(user.toJSON({ flattenMaps: false }), "password");
 }
 
 export async function findUser(query: FilterQuery<UserDocument>) {


### PR DESCRIPTION
Fixed FlattenMaps type added by default with .toJSON() in mongoose (the error is showing up in session.controller.ts line 20).

I first got that error when working on a new project inspired from your tutorial. and it's also showing up when deleting the yarn.lock and rebuilding it with yarn install.