### PR TITLE
add pretty printing support

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,7 +2,9 @@ import logger from "pino";
 import dayjs from "dayjs";
 
 const log = logger({
-  prettyPrint: true,
+  transport: {
+    target: 'pino-pretty'
+  },
   base: {
     pid: false,
   },


### PR DESCRIPTION
Hi. Pretty printing support in `pino` has been deprecated as mentioned [here](https://github.com/pinojs/pino/issues/1106). I have modified the code in `logger.ts` to support pretty printing for versions of `pino` ^8.11.0.