### PR TITLE
Update postman collection to be compatible with new scripts system

### DIFF
--- a/postman_collection.json
+++ b/postman_collection.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "d3a34203-6dac-480e-8aac-0dce44241f83",
+		"_postman_id": "bf7d2532-4c66-4e44-882d-de431828a58e",
 		"name": "REST API Tutorial",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "33095363"
 	},
 	"item": [
 		{
@@ -42,12 +43,25 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"var jsonData = JSON.parse(responseBody);",
-									"console.log(jsonData)",
-									"postman.setEnvironmentVariable(\"accessToken\", jsonData.accessToken);",
-									"postman.setEnvironmentVariable(\"refreshToken\", jsonData.refreshToken);"
+									"pm.test(\"Set access and refresh token variables\", function () {",
+									"    var jsonData = JSON.parse(pm.response.text());",
+									"    console.log(jsonData)",
+									"    pm.collectionVariables.set(\"accessToken\", jsonData.accessToken);",
+									"    pm.collectionVariables.set(\"refreshToken\", jsonData.refreshToken);",
+									"});"
 								],
-								"type": "text/javascript"
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
 							}
 						}
 					],
@@ -83,17 +97,18 @@
 							"listen": "test",
 							"script": {
 								"exec": [
+									"pm.test(\"Refresh access token\", function () {",
+									"    const newAccessToken = pm.response.headers['x-access-token']",
 									"",
-									"const newAccessToken = responseHeaders['x-access-token']",
-									"",
-									"if(newAccessToken){",
-									"    console.log('Set new access token')",
-									"postman.setEnvironmentVariable(\"accessToken\", newAccessToken);",
-									"}",
-									"",
+									"    if(newAccessToken){",
+									"        console.log('Set new access token')",
+									"        pm.collectionVariables.set(\"accessToken\", newAccessToken);",
+									"    }",
+									"});",
 									""
 								],
-								"type": "text/javascript"
+								"type": "text/javascript",
+								"packages": {}
 							}
 						}
 					],
@@ -136,16 +151,18 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"const newAccessToken = responseHeaders['x-access-token']",
+									"pm.test(\"Refresh access token\", function () {",
+									"    const newAccessToken = pm.response.headers['x-access-token']",
 									"",
-									"if(newAccessToken){",
-									"    console.log('Set new access token')",
-									"postman.setEnvironmentVariable(\"accessToken\", newAccessToken);",
-									"}",
-									"",
+									"    if(newAccessToken){",
+									"        console.log('Set new access token')",
+									"        pm.collectionVariables.set(\"accessToken\", newAccessToken);",
+									"    }",
+									"});",
 									""
 								],
-								"type": "text/javascript"
+								"type": "text/javascript",
+								"packages": {}
 							}
 						}
 					],
@@ -193,18 +210,21 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"var jsonData = JSON.parse(responseBody);",
-									"postman.setEnvironmentVariable(\"productId\", jsonData.productId);",
+									"pm.test(\"Set productId and refresh access token\", function () {",
+									"    var jsonData = JSON.parse(pm.response.text());",
+									"    console.log(jsonData)",
+									"    pm.collectionVariables.set(\"productId\", jsonData.productId);",
 									"",
+									"    const newAccessToken = pm.response.headers['x-access-token']",
 									"",
-									"const newAccessToken = responseHeaders['x-access-token']",
-									"",
-									"if(newAccessToken){",
-									"    console.log('Set new access token')",
-									"postman.setEnvironmentVariable(\"accessToken\", newAccessToken);",
-									"}"
+									"    if (newAccessToken){",
+									"        console.log('Set new access token')",
+									"        pm.collectionVariables.set(\"accessToken\", newAccessToken);",
+									"    }",
+									"});"
 								],
-								"type": "text/javascript"
+								"type": "text/javascript",
+								"packages": {}
 							}
 						}
 					],
@@ -298,14 +318,18 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"const newAccessToken = responseHeaders['x-access-token']",
+									"pm.test(\"Refresh access token\", function () {",
+									"    const newAccessToken = pm.response.headers['x-access-token']",
 									"",
-									"if(newAccessToken){",
-									"    console.log('Set new access token')",
-									"postman.setEnvironmentVariable(\"accessToken\", newAccessToken);",
-									"}"
+									"    if(newAccessToken){",
+									"        console.log('Set new access token')",
+									"        pm.collectionVariables.set(\"accessToken\", newAccessToken);",
+									"    }",
+									"});",
+									""
 								],
-								"type": "text/javascript"
+								"type": "text/javascript",
+								"packages": {}
 							}
 						}
 					],
@@ -358,14 +382,18 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"const newAccessToken = responseHeaders['x-access-token']",
+									"pm.test(\"Refresh access token\", function () {",
+									"    const newAccessToken = pm.response.headers['x-access-token']",
 									"",
-									"if(newAccessToken){",
-									"    console.log('Set new access token')",
-									"postman.setEnvironmentVariable(\"accessToken\", newAccessToken);",
-									"}"
+									"    if(newAccessToken){",
+									"        console.log('Set new access token')",
+									"        pm.collectionVariables.set(\"accessToken\", newAccessToken);",
+									"    }",
+									"});",
+									""
 								],
-								"type": "text/javascript"
+								"type": "text/javascript",
+								"packages": {}
 							}
 						}
 					],


### PR DESCRIPTION
Hi!

Since the postman collection was exported, the "tests" system has been moved into the "scripts" system and the syntax for tests has changed. Because of that, the tests in the Postman collection of this repo are no longer compatible with the current version of Postman. When each endpoint is executed, the collection variables do not populate.

This PR updates the tests so that they work as expected, successfully setting the variables.

![image](https://github.com/TomDoesTech/REST-API-Tutorial-Updated/assets/82292207/09b35f39-4613-4138-8d7d-98270f1a6c93)
